### PR TITLE
Scale the marching sound by the number of troops actually moving

### DIFF
--- a/docs/InstallationGuide.md
+++ b/docs/InstallationGuide.md
@@ -1,6 +1,6 @@
 # Installation Guide
 
-What's up peeps! This document will guide you how to set up the development environment to run the software on IntelliJ.
+This document will guide you how to set up the development environment to run the software on IntelliJ.
 
 ## Step 1: Download the software and required dependencies
 

--- a/src/configs/battle_configs/CavVsSwordmen.txt
+++ b/src/configs/battle_configs/CavVsSwordmen.txt
@@ -4,9 +4,9 @@
     x: 6500
     y: 12500
     angle: 0
-    size: 1
+    size: 450
     faction: ROME
-    width: 1
+    width: 30
 },
 {
     type: SWORDMAN

--- a/src/model/GameEnvironment.java
+++ b/src/model/GameEnvironment.java
@@ -8,6 +8,8 @@ import model.construct.Construct;
 import model.events.Event;
 import model.events.EventBroadcaster;
 import model.events.EventType;
+import model.events.custom_events.CavalryMarchingEvent;
+import model.events.custom_events.SoldierMarchingEvent;
 import model.monitor.Monitor;
 import model.singles.BaseSingle;
 import model.surface.BaseSurface;
@@ -108,6 +110,7 @@ public class GameEnvironment {
         for (BaseUnit unit : units) {
             unit.updateIntention();
         }
+
         // Update the states of all units
         unitModifier.modifyObjects();
         for (BaseUnit unit : units) {
@@ -116,20 +119,31 @@ public class GameEnvironment {
         // Broadcast running and marching events
         for (BaseUnit unit : units) {
             switch (unit.getState()) {
+                case STANDING:
+                    int numMovings = unit.getNumMoving();
+                    if (numMovings > 0) {
+                        if (unit instanceof CavalryUnit) {
+                            broadcaster.broadcastEvent(
+                                    new CavalryMarchingEvent(unit.getAverageX(), unit.getAverageY(), unit.getAverageZ(),
+                                            numMovings));
+                        } else {
+                            broadcaster.broadcastEvent(
+                                    new SoldierMarchingEvent(unit.getAverageX(), unit.getAverageY(), unit.getAverageZ(),
+                                            numMovings));
+                        }
+                    }
+                    break;
                 case MOVING:
                 case ROUTING:
+                    numMovings = unit.getNumMoving();
                     if (unit instanceof CavalryUnit) {
                         broadcaster.broadcastEvent(
-                                new Event(EventType.CAVALRY_RUNNING,
-                                        unit.getAverageX(),
-                                        unit.getAverageY(),
-                                        unit.getAverageZ()));
+                                new CavalryMarchingEvent(unit.getAverageX(), unit.getAverageY(), unit.getAverageZ(),
+                                        numMovings));
                     } else {
                         broadcaster.broadcastEvent(
-                                new Event(EventType.SOLDIER_MARCHING,
-                                        unit.getAverageX(),
-                                        unit.getAverageY(),
-                                        unit.getAverageZ()));
+                                new SoldierMarchingEvent(unit.getAverageX(), unit.getAverageY(), unit.getAverageZ(),
+                                        numMovings));
                     }
                     break;
                 case FIGHTING:

--- a/src/model/events/custom_events/CavalryMarchingEvent.java
+++ b/src/model/events/custom_events/CavalryMarchingEvent.java
@@ -1,0 +1,16 @@
+package model.events.custom_events;
+
+import model.events.Event;
+import model.events.EventType;
+
+public class CavalryMarchingEvent extends Event {
+    int numSingles;
+    public CavalryMarchingEvent(double inputX, double inputY, double inputZ, int inputNumSoldiers) {
+        super(EventType.CAVALRY_RUNNING, inputX, inputY, inputZ);
+        numSingles = inputNumSoldiers;
+    }
+
+    public int getNumSingles() {
+        return numSingles;
+    }
+}

--- a/src/model/events/custom_events/SoldierMarchingEvent.java
+++ b/src/model/events/custom_events/SoldierMarchingEvent.java
@@ -1,0 +1,16 @@
+package model.events.custom_events;
+
+import model.events.Event;
+import model.events.EventType;
+
+public class SoldierMarchingEvent extends Event {
+    int numSingles;
+    public SoldierMarchingEvent(double inputX, double inputY, double inputZ, int inputNumSoldiers) {
+        super(EventType.SOLDIER_MARCHING, inputX, inputY, inputZ);
+        numSingles = inputNumSoldiers;
+    }
+
+    public int getNumSingles() {
+        return numSingles;
+    }
+}

--- a/src/model/units/BaseUnit.java
+++ b/src/model/units/BaseUnit.java
@@ -822,7 +822,6 @@ public class BaseUnit {
             }
         }
 
-
         // Update the state of each single and the average position
         double sumX = 0;
         double sumY = 0;
@@ -961,6 +960,19 @@ public class BaseUnit {
      */
     public int getNumAlives() {
         return aliveTroopsMap.size();
+    }
+
+    /**
+     * Get the number of troops walking/
+     */
+    public int getNumMoving() {
+        int numMoving = 0;
+        for (BaseSingle single : aliveTroopsMap.keySet()) {
+            if (single.getState() == SingleState.MOVING || single.getState() == SingleState.CATCHING_UP) {
+                 numMoving += 1;
+            }
+        }
+        return numMoving;
     }
 
     public double getStamina() { return stamina; }

--- a/src/view/audio/AudioConstants.java
+++ b/src/view/audio/AudioConstants.java
@@ -2,11 +2,11 @@ package view.audio;
 
 public class AudioConstants {
 
-    // Tendency to scream in pain
-    public static double SCREAM_TENDENCY = 0.03;
-
     // Distance in which max volume is heard.
     public static double MAX_VOLUME_DISTANCE = 600;
+
+    // marching sound proportion per soldier.
+    public static double SOUND_PROPORTION_PER_SOLDER = 0.01;
 
     // Minimum amplitude (to avoid booming the speaker)
     public static float MIN_AMPLITUDE = 0.000001f;

--- a/src/view/audio/AudioSpeaker.java
+++ b/src/view/audio/AudioSpeaker.java
@@ -3,6 +3,8 @@ package view.audio;
 import model.events.Event;
 import model.events.EventBroadcaster;
 import model.events.EventListener;
+import model.events.custom_events.CavalryMarchingEvent;
+import model.events.custom_events.SoldierMarchingEvent;
 import model.utils.MathUtils;
 import processing.core.PApplet;
 import view.camera.Camera;
@@ -73,6 +75,8 @@ public class AudioSpeaker extends EventListener {
             switch (e.getEventType()) {
                 case CAVALRY_RUNNING:
                     audio = audioMap.get(AudioType.CAVALRY_RUNNING);
+                    volumePortionAdded *= AudioConstants.SOUND_PROPORTION_PER_SOLDER *
+                            ((CavalryMarchingEvent) e).getNumSingles();
                     break;
                 case CAVALRY_CHARGE:
                     audio = audioMap.get(AudioType.CAVALRY_CHARGE);
@@ -98,6 +102,8 @@ public class AudioSpeaker extends EventListener {
                     audio = audioMap.get(AudioType.SOLDIER_FIGHTING);
                     break;
                 case SOLDIER_MARCHING:
+                    volumePortionAdded *= AudioConstants.SOUND_PROPORTION_PER_SOLDER *
+                            ((SoldierMarchingEvent) e).getNumSingles();
                     audio = audioMap.get(AudioType.SOLDIER_MARCHING);
                     break;
                 default:


### PR DESCRIPTION
While this is already really satisfying, the next step would be to scale the sound by the number of horse charging. But this would require the addition of code specifically handling cavalry charge to make it happen.